### PR TITLE
fix: add __typename to union type

### DIFF
--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -364,7 +364,7 @@ export class Typegen {
         } else if (isUnionType(type)) {
           rootTypeMap[type.name] = type
             .getTypes()
-            .map((t) => `NexusGenRootTypes['${t.name}']`)
+            .map((t) => `NexusGenRootTypes['${t.name}'] & { __typename?: '${t.name}'}`)
             .join(" | ");
         } else if (isInterfaceType(type)) {
           const possibleRoots = this.schema

--- a/tests/__snapshots__/typegen.spec.ts.snap
+++ b/tests/__snapshots__/typegen.spec.ts.snap
@@ -75,7 +75,7 @@ exports[`typegen should not print roots for fields with resolvers 1`] = `
   Boolean: boolean;
   ID: string;
   UUID: string;
-  ExampleUnion: NexusGenRootTypes['Post'] | NexusGenRootTypes['User'];
+  ExampleUnion: NexusGenRootTypes['Post'] & { __typename?: 'Post'} | NexusGenRootTypes['User'] & { __typename?: 'User'};
 }"
 `;
 
@@ -138,7 +138,7 @@ exports[`typegen should print a root type map 1`] = `
   Boolean: boolean;
   ID: string;
   UUID: string;
-  ExampleUnion: NexusGenRootTypes['Post'] | NexusGenRootTypes['User'];
+  ExampleUnion: NexusGenRootTypes['Post'] & { __typename?: 'Post'} | NexusGenRootTypes['User'] & { __typename?: 'User'};
 }"
 `;
 
@@ -199,7 +199,7 @@ export interface NexusGenRootTypes {
   Boolean: boolean;
   ID: string;
   UUID: string;
-  ExampleUnion: NexusGenRootTypes['Post'] | NexusGenRootTypes['User'];
+  ExampleUnion: NexusGenRootTypes['Post'] & { __typename?: 'Post'} | NexusGenRootTypes['User'] & { __typename?: 'User'};
 }
 
 export interface NexusGenAllTypes extends NexusGenRootTypes {


### PR DESCRIPTION
Fix #188 

Another possible solution could be adding `& { __typename?: 'TypeName'}` to all the members of `NexusGenRootTypes`. 

If this is not the best solution, feel free to close it or let me know how can I help with it.