### PR TITLE
Remove file:. from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "yarn link-examples && tsc -w",
     "test": "jest",
-    "test:ci": "yarn add file:. && jest -i --coverage",
+    "test:ci": "jest -i --coverage",
     "build": "tsc",
     "lint": "tslint -p tsconfig.json",
     "clean": "rm -rf dist",
@@ -50,7 +50,6 @@
     "graphql-iso-date": "^3.6.1",
     "jest-watch-typeahead": "^0.3.1",
     "lint-staged": "^7.3.0",
-    "nexus": "file:.",
     "prettier": "^1.16.0",
     "ts-jest": "^24",
     "ts-node": "^7.0.1",

--- a/tests/integration/_helpers.ts
+++ b/tests/integration/_helpers.ts
@@ -1,6 +1,8 @@
+/// <reference path="../_setup.ts" />
 import { join } from "path";
 import { generateSchema } from "../../src/builder";
 import ts from "typescript";
+import { typegenFormatPrettier } from "../../src/core";
 
 export const testSchema = (name: string) => {
   it(`can compile ${name} app with its typegen`, async () => {
@@ -11,6 +13,10 @@ export const testSchema = (name: string) => {
       outputs: {
         typegen: typegenFilePath,
         schema: false,
+      },
+      async formatTypegen(content, type) {
+        const result = await typegenFormatPrettier({})(content, type);
+        return result.replace('"nexus"', '"../.."');
       },
     });
 

--- a/tests/integration/_s.typegen.ts
+++ b/tests/integration/_s.typegen.ts
@@ -3,21 +3,20 @@
  * Do not make changes to this file directly
  */
 
-
-import { core } from "nexus"
+import { core } from "../..";
 declare global {
   interface NexusGenCustomInputMethods<TypeName extends string> {
-    title(...args: any): void
+    title(...args: any): void;
   }
 }
 declare global {
   interface NexusGenCustomOutputMethods<TypeName extends string> {
-    title(options: { escape: boolean }): void
+    title(options: { escape: boolean }): void;
   }
 }
 declare global {
   interface NexusGenCustomOutputProperties<TypeName extends string> {
-    body: any
+    body: any;
   }
 }
 
@@ -26,26 +25,28 @@ declare global {
 }
 
 export interface NexusGenInputs {
-  PostSearchInput: { // input type
+  PostSearchInput: {
+    // input type
     body?: string | null; // String
     title?: string | null; // String
-  }
+  };
 }
 
-export interface NexusGenEnums {
-}
+export interface NexusGenEnums {}
 
 export interface NexusGenRootTypes {
   Mutation: {};
-  Post: { // root type
+  Post: {
+    // root type
     body: string; // String!
     title: string; // String!
-  }
+  };
   Query: {};
-  User: { // root type
+  User: {
+    // root type
     firstName: string; // String!
     lastName: string; // String!
-  }
+  };
   String: string;
   Int: number;
   Float: number;
@@ -54,47 +55,53 @@ export interface NexusGenRootTypes {
 }
 
 export interface NexusGenAllTypes extends NexusGenRootTypes {
-  PostSearchInput: NexusGenInputs['PostSearchInput'];
+  PostSearchInput: NexusGenInputs["PostSearchInput"];
 }
 
 export interface NexusGenFieldTypes {
-  Mutation: { // field return type
-    createUser: NexusGenRootTypes['User']; // User!
-  }
-  Post: { // field return type
+  Mutation: {
+    // field return type
+    createUser: NexusGenRootTypes["User"]; // User!
+  };
+  Post: {
+    // field return type
     body: string; // String!
     title: string; // String!
-  }
-  Query: { // field return type
+  };
+  Query: {
+    // field return type
     foo: string; // String!
-    searchPosts: NexusGenRootTypes['Post'][]; // [Post!]!
-    user: NexusGenRootTypes['User']; // User!
-  }
-  User: { // field return type
+    searchPosts: NexusGenRootTypes["Post"][]; // [Post!]!
+    user: NexusGenRootTypes["User"]; // User!
+  };
+  User: {
+    // field return type
     firstName: string; // String!
     lastName: string; // String!
-  }
+  };
 }
 
 export interface NexusGenArgTypes {
   Mutation: {
-    createUser: { // args
+    createUser: {
+      // args
       firstName?: string | null; // String
       lastName?: string | null; // String
-    }
-  }
+    };
+  };
   Query: {
-    searchPosts: { // args
-      input?: NexusGenInputs['PostSearchInput'] | null; // PostSearchInput
-    }
-    user: { // args
+    searchPosts: {
+      // args
+      input?: NexusGenInputs["PostSearchInput"] | null; // PostSearchInput
+    };
+    user: {
+      // args
       id?: string | null; // ID
-    }
-  }
+    };
+  };
 }
 
-export interface NexusGenAbstractResolveReturnTypes {
-}
+export interface NexusGenAbstractResolveReturnTypes {}
 
 export interface NexusGenInheritedFields {}
 
@@ -124,9 +131,19 @@ export interface NexusGenTypes {
   interfaceNames: NexusGenInterfaceNames;
   scalarNames: NexusGenScalarNames;
   unionNames: NexusGenUnionNames;
-  allInputTypes: NexusGenTypes['inputNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['scalarNames'];
-  allOutputTypes: NexusGenTypes['objectNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['unionNames'] | NexusGenTypes['interfaceNames'] | NexusGenTypes['scalarNames'];
-  allNamedTypes: NexusGenTypes['allInputTypes'] | NexusGenTypes['allOutputTypes']
-  abstractTypes: NexusGenTypes['interfaceNames'] | NexusGenTypes['unionNames'];
+  allInputTypes:
+    | NexusGenTypes["inputNames"]
+    | NexusGenTypes["enumNames"]
+    | NexusGenTypes["scalarNames"];
+  allOutputTypes:
+    | NexusGenTypes["objectNames"]
+    | NexusGenTypes["enumNames"]
+    | NexusGenTypes["unionNames"]
+    | NexusGenTypes["interfaceNames"]
+    | NexusGenTypes["scalarNames"];
+  allNamedTypes:
+    | NexusGenTypes["allInputTypes"]
+    | NexusGenTypes["allOutputTypes"];
+  abstractTypes: NexusGenTypes["interfaceNames"] | NexusGenTypes["unionNames"];
   abstractResolveReturn: NexusGenAbstractResolveReturnTypes;
 }

--- a/tests/integration/_xs.typegen.ts
+++ b/tests/integration/_xs.typegen.ts
@@ -3,21 +3,13 @@
  * Do not make changes to this file directly
  */
 
-
-
-
-
-
-
 declare global {
   interface NexusGen extends NexusGenTypes {}
 }
 
-export interface NexusGenInputs {
-}
+export interface NexusGenInputs {}
 
-export interface NexusGenEnums {
-}
+export interface NexusGenEnums {}
 
 export interface NexusGenRootTypes {
   Query: {};
@@ -28,20 +20,18 @@ export interface NexusGenRootTypes {
   ID: string;
 }
 
-export interface NexusGenAllTypes extends NexusGenRootTypes {
-}
+export interface NexusGenAllTypes extends NexusGenRootTypes {}
 
 export interface NexusGenFieldTypes {
-  Query: { // field return type
+  Query: {
+    // field return type
     foo: string; // String!
-  }
+  };
 }
 
-export interface NexusGenArgTypes {
-}
+export interface NexusGenArgTypes {}
 
-export interface NexusGenAbstractResolveReturnTypes {
-}
+export interface NexusGenAbstractResolveReturnTypes {}
 
 export interface NexusGenInheritedFields {}
 
@@ -71,9 +61,19 @@ export interface NexusGenTypes {
   interfaceNames: NexusGenInterfaceNames;
   scalarNames: NexusGenScalarNames;
   unionNames: NexusGenUnionNames;
-  allInputTypes: NexusGenTypes['inputNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['scalarNames'];
-  allOutputTypes: NexusGenTypes['objectNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['unionNames'] | NexusGenTypes['interfaceNames'] | NexusGenTypes['scalarNames'];
-  allNamedTypes: NexusGenTypes['allInputTypes'] | NexusGenTypes['allOutputTypes']
-  abstractTypes: NexusGenTypes['interfaceNames'] | NexusGenTypes['unionNames'];
+  allInputTypes:
+    | NexusGenTypes["inputNames"]
+    | NexusGenTypes["enumNames"]
+    | NexusGenTypes["scalarNames"];
+  allOutputTypes:
+    | NexusGenTypes["objectNames"]
+    | NexusGenTypes["enumNames"]
+    | NexusGenTypes["unionNames"]
+    | NexusGenTypes["interfaceNames"]
+    | NexusGenTypes["scalarNames"];
+  allNamedTypes:
+    | NexusGenTypes["allInputTypes"]
+    | NexusGenTypes["allOutputTypes"];
+  abstractTypes: NexusGenTypes["interfaceNames"] | NexusGenTypes["unionNames"];
   abstractResolveReturn: NexusGenAbstractResolveReturnTypes;
 }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "types": ["node", "jest"],
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "noEmit": true,
+    "rootDir": "."
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,11 +2791,6 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-"nexus@file:./.":
-  version "0.12.0-beta.9"
-  dependencies:
-    tslib "^1.9.3"
-
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"


### PR DESCRIPTION
This was really slowing down yarn install locally, because it seemed to be linking everything in `node_modules` recursively or something. This taps into the `formatTypegen` method to accomplish the same end-goal, testing the local `nexus` in the integration tests.