### PR TITLE
docs: Update circleci badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # GraphQL Nexus
 
-[![CircleCI](https://circleci.com/gh/prisma/nexus.svg?style=shield)](https://circleci.com/gh/prisma/nexus) [![npm version](https://badge.fury.io/js/nexus.svg)](https://badge.fury.io/js/nexus) [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/nexus)
+[![CircleCI](https://img.shields.io/circleci/build/github/prisma-labs/nexus)](https://circleci.com/gh/prisma/nexus)
+[![npm version](https://badge.fury.io/js/nexus.svg)](https://badge.fury.io/js/nexus) 
+[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/nexus)
 
 
 Declarative, code-first and strongly typed GraphQL schema construction for TypeScript & JavaScript


### PR DESCRIPTION
# What was wrong
Your CircleCI badge/shield was broken:
![image](https://user-images.githubusercontent.com/16897508/65811961-b3c01500-e203-11e9-8e99-d9e0f3626867.png)
It's a tiny thing but when an employee is making the argument to use a library to their boss, 'broken' CI doesn't help their case

# What's Changed? 
* Somewhat unnecessary, however replace your broken/outdated circleCI shield image. 
Generated from [ShieldsIO](https://shields.io/category/build) with the following config: 
![image](https://user-images.githubusercontent.com/16897508/65811926-50ce7e00-e203-11e9-9040-bfc5eb0bd17a.png)
* Spaced out the badges to new lines for a tiny bit of readability.

# Proof:
![image](https://user-images.githubusercontent.com/16897508/65811970-cc302f80-e203-11e9-916a-48e4f1205e97.png)

