### PR TITLE
feat: deferred dynamics

### DIFF
--- a/tests/integration/none.spec.ts
+++ b/tests/integration/none.spec.ts
@@ -2,7 +2,7 @@ import ts from "typescript";
 import { join } from "path";
 
 it("can be compiled with no generated types present", () => {
-  expect([join(__dirname, "./_app.ts")]).toTypeCheck({
+  (expect([join(__dirname, "./_app.ts")]) as any).toTypeCheck({
     sourceMap: false,
     noEmitOnError: true,
     esModuleInterop: true,


### PR DESCRIPTION
This idea came about while exploring how we could enable plugins to "see" the entirety of the app's block defs when they are walked. We realized this required walking the app, which required the dynamics, but not wanting the dynamics to themselves be processed yet.

This PR makes this possible by introducing (as a prototype, no tests, no implementation elegance) deferred dynamics wherein dynamics are made to be `noops` at walk 1 time. Then at walk 2 time, they are actually processed.

In the end it was agreed that we can live with the limitation for v1 at least that plugins can only "see" top-level app block defs, thus avoiding the need to wade into the complexity herein.