### PR TITLE
chore: simplify tsconfig

### DIFF
--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["node", "jest"],
-    "noUnusedLocals": false,
+    "noUnusedLocals": false, // FIXME
     "noEmit": true,
     "rootDir": "."
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,7 @@
     "declaration": true,
     "importHelpers": true,
     "resolveJsonModule": true,
-    "sourceMap": true,
-    "types": ["node"]
+    "sourceMap": true
   },
   "exclude": [
     "./examples",


### PR DESCRIPTION
On my machine I get jest test matcher type errors. This PR fixes that. Its also just simpler and what I would expect in the first place.

Unless the original motivation for how it was remains, we should simplify.