### PR TITLE
feat(typegen): nicer generated package name

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -303,7 +303,7 @@ export function resolveBuilderConfig(
   const defaultSchemaPath = path.join(process.cwd(), "schema.graphql");
   const defaultTypesPath = path.join(
     __dirname,
-    "../node_modules/@types/__nexus-typegen__core/index.d.ts"
+    "../node_modules/@types/nexus-typegen/index.d.ts"
   );
   const defaults = {
     outputs: {

--- a/tests/builder.spec.ts
+++ b/tests/builder.spec.ts
@@ -8,7 +8,7 @@ import { restoreEnvAfterEach } from "../src/core";
 
 const relativePath = (...paths: string[]): string => Path.join(__dirname, ...paths); // prettier-ignore
 const atTypesPath = relativePath("../node_modules/@types");
-const typegenDefault = Path.join(atTypesPath, "/__nexus-typegen__core/index.d.ts"); // prettier-ignore
+const typegenDefault = Path.join(atTypesPath, "/nexus-typegen/index.d.ts"); // prettier-ignore
 const schemaDefaultPath = relativePath("../schema.graphql");
 
 describe("resolveBuilderConfig() outputs", () => {


### PR DESCRIPTION
This can impact the end-user when they, for example, are using the `types` TS compiler option. In that situation, expressing a whitelist of TypeScript type-packages, in a Nexus app, it would be important that the user also include typegen or else TSC would stop seeing it (forcing the user to provide custom typegen config). To make it easier for users to do that, let them refer to a pretty name, rather than something hard to predict, remember, and looks ugly.

#### TODO

- [x] update tests