### PR TITLE
docs: remove spectrum link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-<p align="center"><a href="https://nexus.js.org"><img src="https://i.imgur.com/Y5BgDGl.png" width="150" /><a></p>
-
-# GraphQL Nexus
+<p align="center">
+  <a href="https://nexus.js.org"><img src="https://i.imgur.com/Y5BgDGl.png" width="150" /><a>
+  <h1 align="center">Nexus</h1>
+</p>
 
 [![CircleCI](https://img.shields.io/circleci/build/github/prisma-labs/nexus)](https://circleci.com/gh/prisma/nexus)
-[![npm version](https://badge.fury.io/js/nexus.svg)](https://badge.fury.io/js/nexus) 
-[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/nexus)
-
+[![npm version](https://badge.fury.io/js/nexus.svg)](https://badge.fury.io/js/nexus)
 
 Declarative, code-first and strongly typed GraphQL schema construction for TypeScript & JavaScript
 


### PR DESCRIPTION
- consistent with what we did in nexus-prisma
- consistent with Prisma's consolidate community touch points efforts

We could add badges to the slack community?