### PR TITLE
chore(codecov): Only use codecov diff coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+comment:
+  layout: "diff"
+
+coverage:
+  status:
+    project: off
+    patch:
+      default:
+        target: 100

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,json,css,md}": [
+    "*.{ts,js,json,css,md}": [
       "prettier --write",
       "git add"
     ]


### PR DESCRIPTION
We should only care that new lines of code added have coverage.