### PR TITLE
refactor: Update warn message for inputObject

### DIFF
--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -334,7 +334,7 @@ export class InputDefinitionBlock<TypeName extends string> {
     if (this.isList) {
       if (config.list) {
         this.typeBuilder.warn(
-          `It looks like you chained .list and set list for ${config.name}` +
+          `It looks like you chained .list and set list for ${config.name}. ` +
             "You should only do one or the other"
         );
       } else {

--- a/tests/__snapshots__/inputObjectType.spec.ts.snap
+++ b/tests/__snapshots__/inputObjectType.spec.ts.snap
@@ -20,6 +20,6 @@ exports[`inputObject throws when chaining .list twice 1`] = `"Cannot chain list.
 
 exports[`inputObject warns when specifying .list and list: true 1`] = `
 Array [
-  "It looks like you chained .list and set list for someFieldYou should only do one or the other",
+  "It looks like you chained .list and set list for someField. You should only do one or the other",
 ]
 `;


### PR DESCRIPTION
### What changed?
- Updated warning message when specifying `.list` and `list: true` for `inputObject`


