### PR TITLE
feat: add name to fieldConfig

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -659,6 +659,7 @@ export class SchemaBuilder {
             fieldConfig: {
               ...fieldConfig,
               type: finalType,
+              name: key,
             },
             schemaConfig: this.config,
             parentTypeConfig: rest,
@@ -1090,6 +1091,7 @@ export class SchemaBuilder {
       NexusGraphQLFieldConfig,
       "resolve" | "subscribe"
     > = {
+      name: fieldConfig.name,
       type: this.decorateType(
         this.getOutputType(fieldConfig.type),
         fieldConfig.list,

--- a/src/definitions/_types.ts
+++ b/src/definitions/_types.ts
@@ -147,7 +147,7 @@ type WithExt<T extends { extensions?: any }, Ext> = Omit<T, "extensions"> & {
 export type NexusGraphQLFieldConfig = WithExt<
   GraphQLFieldConfig<any, any>,
   NexusFieldExtension
->;
+> & { name: string };
 
 export type NexusGraphQLObjectTypeConfig = WithExt<
   GraphQLObjectTypeConfig<any, any>,

--- a/src/plugins/fieldAuthorizePlugin.ts
+++ b/src/plugins/fieldAuthorizePlugin.ts
@@ -94,6 +94,8 @@ export const fieldAuthorizePlugin = (
         console.error(
           new Error(
             `The authorize property provided to ${
+              config.fieldConfig.name
+            } with type ${
               config.fieldConfig.type
             } should be a function, saw ${typeof authorize}`
           )

--- a/tests/plugins/__snapshots__/fieldAuthorizePlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/fieldAuthorizePlugin.spec.ts.snap
@@ -149,4 +149,8 @@ Array [
 ]
 `;
 
-exports[`fieldAuthorizePlugin warns when a field has a non-function authorize prop 1`] = `undefined`;
+exports[`fieldAuthorizePlugin warns when a field has a non-function authorize prop 1`] = `
+Array [
+  [Error: The authorize property provided to incorrectFieldConfig with type User! should be a function, saw number],
+]
+`;

--- a/tests/plugins/fieldAuthorizePlugin.spec.ts
+++ b/tests/plugins/fieldAuthorizePlugin.spec.ts
@@ -229,7 +229,7 @@ describe("fieldAuthorizePlugin", () => {
     expect(errors).toEqual([]);
     expect(data?.incorrectFieldConfig).toEqual({ id: 1 });
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleWarnSpy.mock.calls[0]).toMatchSnapshot();
+    expect(consoleErrorSpy.mock.calls[0]).toMatchSnapshot();
   });
 
   test("warns and adds the authorize plugin when a schema has an authorize prop but no plugins", async () => {


### PR DESCRIPTION
This PR implements `name: string` to `fieldConfig` and improve error message in `fieldAuthorizePlugin` and update test snapshots

Fixes: #319 