### PR TITLE
fix: remove graphql-query-complexity import, closes #376

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "eslint": "^6.6.0",
     "graphql": "^14.5.8",
     "graphql-iso-date": "^3.6.1",
-    "graphql-query-complexity": "^0.4.1",
     "graphql-relay": "^0.6.0",
     "husky": "^1.1.2",
     "jest": "^24.9.0",

--- a/src/plugins/queryComplexityPlugin.ts
+++ b/src/plugins/queryComplexityPlugin.ts
@@ -1,7 +1,6 @@
 import { plugin } from "../plugin";
 import { printedGenTyping, printedGenTypingImport } from "../utils";
 import { RootValue, ArgsValue, GetGen } from "../core";
-import { ComplexityEstimatorArgs } from "graphql-query-complexity";
 import { GraphQLField } from "graphql";
 
 const QueryComplexityImport = printedGenTypingImport({
@@ -24,7 +23,7 @@ const fieldDefTypes = printedGenTyping({
 export type QueryComplexityEstimatorArgs<
   TypeName extends string,
   FieldName extends string
-> = ComplexityEstimatorArgs & {
+> = {
   type: RootValue<TypeName>;
   field: GraphQLField<
     RootValue<TypeName>,
@@ -32,6 +31,7 @@ export type QueryComplexityEstimatorArgs<
     ArgsValue<TypeName, FieldName>
   >;
   args: ArgsValue<TypeName, FieldName>;
+  childComplexity: number;
 };
 
 export type QueryComplexityEstimator<

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,13 +1790,6 @@ graphql-iso-date@^3.6.1:
   resolved "https://registry.yarnpkg.com/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz#bd2d0dc886e0f954cbbbc496bbf1d480b57ffa96"
   integrity sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q==
 
-graphql-query-complexity@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/graphql-query-complexity/-/graphql-query-complexity-0.4.1.tgz#06ad49de617da0d74c8196fb4a641349f104552d"
-  integrity sha512-Uo87hNlnJ5jwoWBkVYITbJpTrlCVwgfG5Wrfel0K1/42G+3xvud31CpsprAwiSpFIP+gCqttAx7OVmw4eTqLQQ==
-  dependencies:
-    lodash.get "^4.4.2"
-
 graphql-relay@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.6.0.tgz#18ec36b772cfcb3dbb9bd369c3f8004cf42c7b93"
@@ -3006,11 +2999,6 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
-
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.memoize@4.x:
   version "4.1.2"


### PR DESCRIPTION
Turns out this import (only for the types) doesn't really give us much, so we can remove it.